### PR TITLE
feat: redis에 저장된 click count db에 저장

### DIFF
--- a/src/main/java/clickme/clickme/HeartItApplication.java
+++ b/src/main/java/clickme/clickme/HeartItApplication.java
@@ -2,7 +2,9 @@ package clickme.clickme;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class HeartItApplication {
 

--- a/src/main/java/clickme/clickme/domain/Member.java
+++ b/src/main/java/clickme/clickme/domain/Member.java
@@ -1,0 +1,47 @@
+package clickme.clickme.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Entity
+@Table
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String nickname;
+
+    @Column
+    private Long clickCount;
+
+    public Member(String nickname, Long clickCount) {
+        this.nickname = nickname;
+        this.clickCount = clickCount;
+    }
+
+    public void updateClickCount(Long clickCount) {
+        this.clickCount = clickCount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Member member = (Member) o;
+        return Objects.equals(nickname, member.nickname);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nickname);
+    }
+}

--- a/src/main/java/clickme/clickme/repository/MemberRepository.java
+++ b/src/main/java/clickme/clickme/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package clickme.clickme.repository;
+
+import clickme.clickme.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Member findByNickname(String nickname);
+}

--- a/src/main/java/clickme/clickme/service/DataTransferService.java
+++ b/src/main/java/clickme/clickme/service/DataTransferService.java
@@ -1,0 +1,51 @@
+package clickme.clickme.service;
+
+import clickme.clickme.domain.Member;
+import clickme.clickme.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class DataTransferService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final MemberRepository memberRepository;
+
+    @Scheduled(fixedRate = 7200000)
+    @Transactional
+    public void transferData() {
+        int start = 0;
+        int batchSize = 1000;
+
+        while (true) {
+            Set<String> nicknameBatch = redisTemplate.opsForZSet().range("clicks", start, start + batchSize - 1);
+            if (nicknameBatch.isEmpty()) {
+                break;
+            }
+
+            List<Member> memberBatch = new ArrayList<>();
+            for (String nickname : nicknameBatch) {
+                Long clickCount = redisTemplate.opsForZSet().score("clicks", nickname).longValue();
+                Member exsistingMember = memberRepository.findByNickname(nickname);
+                if (exsistingMember != null) {
+                    exsistingMember.updateClickCount(clickCount);
+                    memberBatch.add(exsistingMember);
+                } else {
+                    Member newMember = new Member(nickname, clickCount);
+                    memberBatch.add(newMember);
+                }
+            }
+
+            memberRepository.saveAll(memberBatch);
+            start += batchSize;
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용
+ member 엔티티 생성
+ redis에만 저장된 데이터 mysql로 저장

## 고민한 내용
+ 클릭수가 올라갈 때마다 db에 저장한다면 db 리소스 낭비라고 생각
  + 10만건을 눌렀다고 10만건의 db 업데이트가 발생 (X)
  + 따라서 일정 주기 동안 스케줄링으로 업데이트 하는 방식을 취했습니다.

+ 스케줄링 부분에서 batchSize를 1000으로 지정한 이유 -> 한번에 많은 데이터를 메모리상으로 올린다면 자칫 OOM 이슈가 발생할 수 있습니다. 따라서 batchSize를 1000으로 정했습니다.
+ 현재는 스케줄링으로 처리하지만 나중에는 batch 서비스를 따로 분리하여 처리하도록 수정할 계획입니다.


closed #7 