### PR TITLE
refactor: ConditionalOnMissingBean 정상적으로 동작하지 않는 문제 해결

### DIFF
--- a/src/main/java/clickme/clickme/config/HeartRepositoryConfig.java
+++ b/src/main/java/clickme/clickme/config/HeartRepositoryConfig.java
@@ -1,0 +1,17 @@
+package clickme.clickme.config;
+
+import clickme.clickme.repository.HeartMemoryRepository;
+import clickme.clickme.repository.HeartRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class HeartRepositoryConfig {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public HeartRepository heartRepository() {
+        return new HeartMemoryRepository();
+    }
+}

--- a/src/main/java/clickme/clickme/repository/HeartMemoryRepository.java
+++ b/src/main/java/clickme/clickme/repository/HeartMemoryRepository.java
@@ -8,11 +8,9 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConditionalOnMissingBean(HeartRepository.class)
 public class HeartMemoryRepository implements HeartRepository {
 
     private static final Map<String, Long> MAP =  new ConcurrentHashMap<>();


### PR DESCRIPTION
## 작업 내용
+ ConditionalOnMissingBean을 올바르게 사용하기 위해 HeartRepositoryConfig를 구현
+ [해당 이슈](#10)에도 작성했듯이 일반 클래스에 ConditionalOnMissingBean을 사용해서는 안 됨 그 이유는 빈이 로드되는 순서에 크게 의존하기 때문에 올바르게 동작하기 어려움 auto-configuration 클래스에만 사용하기를 권장

closed #10 