### PR TITLE
fix: pv.yaml 설정 파일을 수정한다.

### DIFF
--- a/.github/workflows/click-service-cd.yml
+++ b/.github/workflows/click-service-cd.yml
@@ -70,12 +70,11 @@ jobs:
 
       - name: Apply Persistent Volumes
         run: |
-          kubectl apply -f ./pv.yaml
-          kubectl apply -f ./pvc.yaml
+          kubectl apply -f ./click-service/pv.yaml
+          kubectl apply -f ./click-service/pvc.yaml
 
       - name: Deploy
         run: |
           sed "s,\${image},${{ env.IMAGE }},g" ./click-service/resources.yaml > deployment.yaml
           kubectl apply -f ./deployment.yaml
-          mv ./click-service/hpa.yaml .
-          kubectl apply -f ./hpa.yaml
+          kubectl apply -f ./click-service/hpa.yaml

--- a/click-service/pv.yaml
+++ b/click-service/pv.yaml
@@ -7,5 +7,6 @@ spec:
     storage: 1Gi
   accessModes:
     - ReadWriteOnce
-  hostPath:
-    path: "/var/log/click-service"
+  gcePersistentDisk:
+    pdName: log-pv-disk
+    fsType: ext4


### PR DESCRIPTION
## 구현 상세
+ GKE Autopilot에서는 hostPath 볼륨 사용이 제한되고, 특정 유형의 Persistent Volume만 허용된다.
  + gcePersistentDisk를 직접 생성해주고 pv.yaml 파일을 수정
  
closed #126 