### PR TITLE
feat: gif 이미지 svg로 변경하는 기능을 추가한다.

### DIFF
--- a/.github/workflows/click-service-cd.yml
+++ b/.github/workflows/click-service-cd.yml
@@ -11,7 +11,7 @@ env:
   DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
   REGION: ${{ secrets.REGION }}
   WORKSTATION_IMAGE: click-service
-  VERSION: '1.0.2'
+  VERSION: '1.1.0'
   IMAGE: ${{ secrets.REGION }}-docker.pkg.dev/${{ secrets.PROJECT_ID }}/${{ secrets.DOCKER_REPO }}/click-service
   REDIS_HOST: ${{secrets.REDIS_HOST}}
   REDIS_PORT: ${{secrets.REDIS_PORT}}
@@ -54,6 +54,14 @@ jobs:
         with:
           cluster_name: cluster-1
           location: ${{ env.REGION }}-a
+
+      - name: Write credentials file
+        run: |
+          mkdir -p secrets
+          echo '${{ secrets.GCE_SA_KEY }}' > secrets/credentials.json
+
+      - name: Set GOOGLE_APPLICATION_CREDENTIALS
+        run: echo "GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/secrets/credentials.json" >> $GITHUB_ENV
 
       - name: Docker auth
         run: |-

--- a/.github/workflows/click-service-ci.yml
+++ b/.github/workflows/click-service-ci.yml
@@ -34,6 +34,12 @@ jobs:
           java-version: '17'
           distribution: 'corretto'
 
+      - name: Set up Google Cloud auth
+        id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCE_SA_KEY }}
+
       - name: Grant execute permission gradlew
         run: chmod +x ../gradlew
 

--- a/click-service/build.gradle
+++ b/click-service/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-log4j2'
 
+	implementation 'com.google.cloud:google-cloud-storage:2.48.0'
+
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 

--- a/click-service/build.gradle
+++ b/click-service/build.gradle
@@ -13,10 +13,10 @@ configurations {
 
 jib {
 	from {
-		image = "eclipse-temurin:17-jre-alpine@sha256:635ec1b177ac2a587324ed5eda2b9dec197876e16d10c35a4ef9595d76c2c891"
+		image = "asia-northeast3-docker.pkg.dev/regal-station-443123-m2/clickme/ffmpeg-base:latest"
 	}
 	to {
-		image = "asia-northeast3-docker.pkg.dev/micro-chiller-429914-q6/clickme/click-service:latest"
+		image = "asia-northeast3-docker.pkg.dev/regal-station-443123-m2/clickme/click-service:latest"
 	}
 	container {
 		jvmFlags = ["-Xms258m", "-Xmx1024m"]
@@ -26,9 +26,14 @@ jib {
 				'DATASOURCE_URL': System.getenv('DATASOURCE_URL'),
 				'DATASOURCE_USERNAME': System.getenv('DATASOURCE_USERNAME'),
 				'DATASOURCE_PASSWORD': System.getenv('DATASOURCE_PASSWORD'),
-				'SPRING_PROFILES_ACTIVE': 'prod'
+				'BUKET_NAME': System.getenv('BUKET_NAME'),
+				'SPRING_PROFILES_ACTIVE': 'prod',
+				'GOOGLE_APPLICATION_CREDENTIALS': '/secrets/credentials.json'
 		]
 		filesModificationTime = 'EPOCH_PLUS_SECOND'
+	}
+	extraDirectories {
+		paths = [file('secrets')]
 	}
 }
 

--- a/click-service/src/main/java/clickme/clickme/common/ErrorCode.java
+++ b/click-service/src/main/java/clickme/clickme/common/ErrorCode.java
@@ -10,6 +10,8 @@ public enum ErrorCode {
     ENTITY_NOT_FOUND(400, "C003", " Entity Not Found"),
     INTERNAL_SERVER_ERROR(500, "C004", "Server Error"),
     INVALID_TYPE_VALUE(400, "C005", " Invalid Type Value"),
+
+    SVG_CONVERSION_FAILED(500, "SVG001", "Failed to convert GIF to SVG"),
     ;
 
     private final int status;

--- a/click-service/src/main/java/clickme/clickme/config/GcsConfig.java
+++ b/click-service/src/main/java/clickme/clickme/config/GcsConfig.java
@@ -3,25 +3,19 @@ package clickme.clickme.config;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ResourceLoader;
 
 import java.io.IOException;
-import java.io.InputStream;
 
 @Configuration
 public class GcsConfig {
 
-    @Value("${gcp.storage.credentials.location}")
-    private String credentialsPath;
-
     @Bean
-    public Storage storage(ResourceLoader resourceLoader) throws IOException {
-        InputStream credentialsStream = resourceLoader.getResource(credentialsPath).getInputStream();
+    public Storage storage() throws IOException {
+        GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
         return StorageOptions.newBuilder()
-                .setCredentials(GoogleCredentials.fromStream(credentialsStream))
+                .setCredentials(credentials)
                 .build()
                 .getService();
     }

--- a/click-service/src/main/java/clickme/clickme/config/GcsConfig.java
+++ b/click-service/src/main/java/clickme/clickme/config/GcsConfig.java
@@ -1,0 +1,28 @@
+package clickme.clickme.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ResourceLoader;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Configuration
+public class GcsConfig {
+
+    @Value("${gcp.storage.credentials.location}")
+    private String credentialsPath;
+
+    @Bean
+    public Storage storage(ResourceLoader resourceLoader) throws IOException {
+        InputStream credentialsStream = resourceLoader.getResource(credentialsPath).getInputStream();
+        return StorageOptions.newBuilder()
+                .setCredentials(GoogleCredentials.fromStream(credentialsStream))
+                .build()
+                .getService();
+    }
+}

--- a/click-service/src/main/java/clickme/clickme/ranking/domain/Member.java
+++ b/click-service/src/main/java/clickme/clickme/ranking/domain/Member.java
@@ -29,9 +29,16 @@ public class Member extends AbstractRootEntity {
     @Column
     private String profileImageUrl;
 
+    @Column
+    private String svgUrl;
+
     public Member(final Long clickCount, final String name, final String profileImageUrl) {
         this.clickCount = clickCount;
         this.name = name.toLowerCase();
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public void updateSvgUrl(final String svgUrl) {
+        this.svgUrl = svgUrl;
     }
 }

--- a/click-service/src/main/java/clickme/clickme/ranking/domain/MemberRepository.java
+++ b/click-service/src/main/java/clickme/clickme/ranking/domain/MemberRepository.java
@@ -20,4 +20,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         return findProfileImageUrlByName(name)
                 .orElse("https://avatars.githubusercontent.com/u/134919246?v=4");
     }
+
+    default Member getMemberByName(String name) {
+        return findByName(name)
+                .orElse(new Member(0L, name, null));
+    }
 }

--- a/click-service/src/main/java/clickme/clickme/ranking/domain/MemberRepository.java
+++ b/click-service/src/main/java/clickme/clickme/ranking/domain/MemberRepository.java
@@ -8,11 +8,16 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findByName(String name);
+
+    @Query("select m.svgUrl from Member m where m.name = :name")
+    Optional<String> findSvgImageName(@Param("name") String name);
+
     @Query("select m.profileImageUrl from Member m where m.name = :name")
     Optional<String> findProfileImageUrlByName(@Param("name") String name);
 
     default String getProfileImageUrlByName(final String name) {
         return findProfileImageUrlByName(name)
-                .orElseGet(() -> "https://avatars.githubusercontent.com/u/134919246?v=4");
+                .orElse("https://avatars.githubusercontent.com/u/134919246?v=4");
     }
 }

--- a/click-service/src/main/java/clickme/clickme/svg/application/SvgImageService.java
+++ b/click-service/src/main/java/clickme/clickme/svg/application/SvgImageService.java
@@ -2,38 +2,58 @@ package clickme.clickme.svg.application;
 
 import clickme.clickme.common.ErrorCode;
 import clickme.clickme.ranking.domain.DailyClickRepository;
+import clickme.clickme.ranking.domain.Member;
+import clickme.clickme.ranking.domain.MemberRepository;
 import clickme.clickme.ranking.domain.RankingRepository;
 import clickme.clickme.svg.application.exception.SvgException;
 import clickme.clickme.svg.domain.count.Count;
 import clickme.clickme.svg.domain.document.SvgDocumentFactory;
 import clickme.clickme.svg.domain.document.SvgDocumentManipulator;
+import clickme.clickme.svg.domain.document.SvgTransformer;
+import clickme.clickme.svg.domain.document.strategy.DefaultSvgGenerationStrategy;
+import clickme.clickme.svg.domain.document.strategy.GcsSvgGenerationStrategy;
+import clickme.clickme.svg.domain.document.strategy.SvgGenerationStrategy;
+import com.google.cloud.storage.Storage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.w3c.dom.Document;
 
-import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import java.io.IOException;
-import java.io.StringWriter;
 
 @Service
 @RequiredArgsConstructor
 public class SvgImageService {
 
+    private static final String BUCKET_NAME = "clickme-test";
+
     private final RankingRepository rankingRepository;
     private final DailyClickRepository dailyClickRepository;
     private final SvgDocumentFactory svgDocumentFactory;
     private final SvgDocumentManipulator svgDocumentManipulator;
+    private final MemberRepository memberRepository;
+    private final Storage storage;
+    private final SvgTransformer svgTransformer;
 
-    public String generateClickableSvgImage(final String name) {
+    public String generateClickableSvgImage(final String name, final String svgUrl) {
         try {
             final Count count = addAndGetCount(name);
-            return generateSvgImage(count);
+            SvgGenerationStrategy strategy = chooseStrategy(svgUrl, name);
+            Document doc = strategy.generateSvg(count, name, svgUrl);
+            return svgTransformer.transform(doc);
         } catch (IOException | TransformerException e) {
             throw new SvgException("Error generating Clickable SVG Image", ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private SvgGenerationStrategy chooseStrategy(String svgUrl, String name) {
+        final String foundSvgImage = memberRepository.findSvgImageName(name)
+                .orElse(null);
+        if (svgUrl.equals("null") && foundSvgImage == null) {
+            return new DefaultSvgGenerationStrategy(svgDocumentFactory, svgDocumentManipulator);
+        } else {
+            return new GcsSvgGenerationStrategy(svgDocumentFactory, svgDocumentManipulator, storage, BUCKET_NAME, memberRepository);
         }
     }
 
@@ -52,31 +72,14 @@ public class SvgImageService {
         dailyClickRepository.increaseCount(name);
     }
 
-    private String generateSvgImage(Count count) throws IOException, TransformerException {
-        final Document doc = svgDocumentFactory.createEmojiDocument();
-        final Document textDrawnDoc = svgDocumentManipulator.drawText(doc, count);
-        final Document animatedDoc = svgDocumentManipulator.executeEffect(textDrawnDoc, count);
-        return transformSvgToString(animatedDoc);
-    }
-
-    private String transformSvgToString(final Document doc) throws TransformerException {
-        StringWriter writer = new StringWriter();
-        final Transformer transformer = TransformerFactory.newInstance()
-                .newTransformer();
-        transformer.transform(new DOMSource(doc), new StreamResult(writer));
-        return writer.toString();
-    }
-
-    public String generateNonClickableSvgImage(final String name) {
-        try {
-            final Count count = getClickCount(name);
-            return generateSvgImage(count);
-        } catch (IOException | TransformerException e) {
-            throw new SvgException("Error generating Clickable SVG Image", ErrorCode.INTERNAL_SERVER_ERROR);
+    @Transactional
+    public String generateNonClickableSvgImage(final String name, final String svgUrl) {
+        if (!svgUrl.equals("null")) {
+            final Member member = memberRepository.findByName(name)
+                    .orElse(new Member(0L, name, null));
+            member.updateSvgUrl(svgUrl);
+            memberRepository.save(member);
         }
-    }
-
-    private Count getClickCount(final String name) {
-        return new Count(rankingRepository.findByName(name));
+        return generateClickableSvgImage(name, svgUrl);
     }
 }

--- a/click-service/src/main/java/clickme/clickme/svg/domain/document/Coordinates.java
+++ b/click-service/src/main/java/clickme/clickme/svg/domain/document/Coordinates.java
@@ -1,0 +1,4 @@
+package clickme.clickme.svg.domain.document;
+
+public record Coordinates(int circleX, int circleY, int textX, int textY) {
+}

--- a/click-service/src/main/java/clickme/clickme/svg/domain/document/SvgDocumentFactory.java
+++ b/click-service/src/main/java/clickme/clickme/svg/domain/document/SvgDocumentFactory.java
@@ -1,7 +1,6 @@
 package clickme.clickme.svg.domain.document;
 
 import clickme.clickme.svg.util.RandomNumberGenerator;
-import lombok.RequiredArgsConstructor;
 import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
 import org.apache.batik.util.XMLResourceDescriptor;
 import org.springframework.core.io.Resource;
@@ -9,10 +8,11 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
 import org.w3c.dom.Document;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 @Component
-@RequiredArgsConstructor
 public class SvgDocumentFactory {
 
     private static final String EMOJI_PATH = "classpath:static/images/emoji_";
@@ -21,22 +21,30 @@ public class SvgDocumentFactory {
 
     private final ResourceLoader resourceLoader;
     private final RandomNumberGenerator emojiRandomIndexGenerator;
+    private final SAXSVGDocumentFactory factory;
+
+    public SvgDocumentFactory(final ResourceLoader resourceLoader, final RandomNumberGenerator emojiRandomIndexGenerator) {
+        this.resourceLoader = resourceLoader;
+        this.emojiRandomIndexGenerator = emojiRandomIndexGenerator;
+        this.factory = new SAXSVGDocumentFactory(XMLResourceDescriptor.getXMLParserClassName());
+    }
 
     public Document createEmojiDocument() throws IOException {
-        final String parser = XMLResourceDescriptor.getXMLParserClassName();
-        final SAXSVGDocumentFactory factory = new SAXSVGDocumentFactory(parser);
-
         final String svgPath = createEmojiPath();
-        return createSvgDocument(svgPath, factory);
+        return createSvgDocument(svgPath);
     }
 
     private String createEmojiPath() {
         return EMOJI_PATH + emojiRandomIndexGenerator.generator(NUMBER_OF_DOCUMENTS) + EMOJI_FORMAT;
     }
 
-    private Document createSvgDocument(final String svgPath,
-                                       final SAXSVGDocumentFactory factory) throws IOException {
+    private Document createSvgDocument(final String svgPath) throws IOException {
         final Resource resource = resourceLoader.getResource(svgPath);
         return factory.createDocument(resource.getURI().toString());
+    }
+
+    public Document createSvgDocumentFromString(final String svgContent) throws IOException {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(svgContent.getBytes(StandardCharsets.UTF_8));
+        return factory.createDocument(null, inputStream);
     }
 }

--- a/click-service/src/main/java/clickme/clickme/svg/domain/document/SvgDocumentManipulator.java
+++ b/click-service/src/main/java/clickme/clickme/svg/domain/document/SvgDocumentManipulator.java
@@ -1,6 +1,7 @@
 package clickme.clickme.svg.domain.document;
 
 import clickme.clickme.svg.domain.count.Count;
+import clickme.clickme.svg.util.CoordinatesCalculator;
 import org.springframework.stereotype.Component;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -9,6 +10,7 @@ import org.w3c.dom.Element;
 public class SvgDocumentManipulator {
 
     private static final String TEXT_ELEMENT_ID = "my-text";
+    private static final String CIRCLE_ELEMENT_ID = "my-circle";
     private static final String ANIMATE_ELEMENT_ID = "animate";
 
     private final TextElementManipulator textElementManipulator;
@@ -20,10 +22,24 @@ public class SvgDocumentManipulator {
         this.animateElementManipulator = animateElementManipulator;
     }
 
+    public Document drawDefaultText(final Document doc, final Count count) {
+        Document copyDoc = (Document) doc.cloneNode(true);
+        Element textElement = copyDoc.getElementById(TEXT_ELEMENT_ID);
+        textElementManipulator.configureDefaultTextElement(textElement, count);
+
+        return copyDoc;
+    }
+
     public Document drawText(final Document doc, final Count count) {
         Document copyDoc = (Document) doc.cloneNode(true);
         Element textElement = copyDoc.getElementById(TEXT_ELEMENT_ID);
-        textElementManipulator.configureTextElement(textElement, count);
+        Element circleElement = copyDoc.getElementById(CIRCLE_ELEMENT_ID);
+
+        final Element svgRoot = doc.getDocumentElement();
+        final int width = Integer.parseInt(svgRoot.getAttribute("width"));
+        final int height = Integer.parseInt(svgRoot.getAttribute("height"));
+        final Coordinates coords = CoordinatesCalculator.calculateCoordinates(width, height);
+        textElementManipulator.configureElements(textElement, circleElement, count, coords);
 
         return copyDoc;
     }

--- a/click-service/src/main/java/clickme/clickme/svg/domain/document/SvgTransformer.java
+++ b/click-service/src/main/java/clickme/clickme/svg/domain/document/SvgTransformer.java
@@ -1,0 +1,29 @@
+package clickme.clickme.svg.domain.document;
+
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.StringWriter;
+
+@Component
+public class SvgTransformer {
+
+    private final Transformer transformer;
+
+    public SvgTransformer() throws TransformerConfigurationException {
+        TransformerFactory factory = TransformerFactory.newInstance();
+        this.transformer = factory.newTransformer();
+    }
+
+    public String transform(Document doc) throws TransformerException {
+        StringWriter writer = new StringWriter();
+        transformer.transform(new DOMSource(doc), new StreamResult(writer));
+        return writer.toString();
+    }
+}

--- a/click-service/src/main/java/clickme/clickme/svg/domain/document/TextElementManipulator.java
+++ b/click-service/src/main/java/clickme/clickme/svg/domain/document/TextElementManipulator.java
@@ -8,7 +8,7 @@ import org.w3c.dom.Element;
 @Component
 public class TextElementManipulator extends ElementManipulator {
 
-    public void configureTextElement(Element textElement, Count count) {
+    public void configureDefaultTextElement(Element textElement, Count count) {
         textElement.setTextContent(count.getValue());
 
         setAttribute(textElement, "font-size", "50");
@@ -26,5 +26,17 @@ public class TextElementManipulator extends ElementManipulator {
 
         setAttribute(textElement, "x", category.getX());
         setAttribute(textElement, "y", category.getY());
+    }
+
+    public void configureElements(Element textElement, Element circleElement, Count count, Coordinates coors) {
+        textElement.setAttribute("x", String.valueOf(coors.textX()));
+        textElement.setAttribute("y", String.valueOf(coors.textY()));
+        textElement.setAttribute("font-size", "17");
+        textElement.setAttribute("fill", "black");
+        textElement.setAttribute("font-weight", "bold");
+        textElement.setTextContent(count.getValue());
+
+        circleElement.setAttribute("cx", String.valueOf(coors.circleX()));
+        circleElement.setAttribute("cy", String.valueOf(coors.circleY()));
     }
 }

--- a/click-service/src/main/java/clickme/clickme/svg/domain/document/strategy/DefaultSvgGenerationStrategy.java
+++ b/click-service/src/main/java/clickme/clickme/svg/domain/document/strategy/DefaultSvgGenerationStrategy.java
@@ -19,7 +19,7 @@ public class DefaultSvgGenerationStrategy implements SvgGenerationStrategy{
     }
 
     @Override
-    public Document generateSvg(final Count count, final String name, final String svgUrl) throws IOException {
+    public Document generateSvg(final Count count, final String name) throws IOException {
         Document doc = svgDocumentFactory.createEmojiDocument();
         doc = svgDocumentManipulator.drawDefaultText(doc, count);
         doc = svgDocumentManipulator.executeEffect(doc, count);

--- a/click-service/src/main/java/clickme/clickme/svg/domain/document/strategy/DefaultSvgGenerationStrategy.java
+++ b/click-service/src/main/java/clickme/clickme/svg/domain/document/strategy/DefaultSvgGenerationStrategy.java
@@ -1,0 +1,28 @@
+package clickme.clickme.svg.domain.document.strategy;
+
+import clickme.clickme.svg.domain.count.Count;
+import clickme.clickme.svg.domain.document.SvgDocumentFactory;
+import clickme.clickme.svg.domain.document.SvgDocumentManipulator;
+import org.w3c.dom.Document;
+
+import java.io.IOException;
+
+public class DefaultSvgGenerationStrategy implements SvgGenerationStrategy{
+
+    private final SvgDocumentFactory svgDocumentFactory;
+    private final SvgDocumentManipulator svgDocumentManipulator;
+
+    public DefaultSvgGenerationStrategy(SvgDocumentFactory svgDocumentFactory,
+                                        SvgDocumentManipulator svgDocumentManipulator) {
+        this.svgDocumentFactory = svgDocumentFactory;
+        this.svgDocumentManipulator = svgDocumentManipulator;
+    }
+
+    @Override
+    public Document generateSvg(final Count count, final String name, final String svgUrl) throws IOException {
+        Document doc = svgDocumentFactory.createEmojiDocument();
+        doc = svgDocumentManipulator.drawDefaultText(doc, count);
+        doc = svgDocumentManipulator.executeEffect(doc, count);
+        return doc;
+    }
+}

--- a/click-service/src/main/java/clickme/clickme/svg/domain/document/strategy/GcsSvgGenerationStrategy.java
+++ b/click-service/src/main/java/clickme/clickme/svg/domain/document/strategy/GcsSvgGenerationStrategy.java
@@ -1,0 +1,54 @@
+package clickme.clickme.svg.domain.document.strategy;
+
+import clickme.clickme.ranking.domain.Member;
+import clickme.clickme.ranking.domain.MemberRepository;
+import clickme.clickme.svg.domain.count.Count;
+import clickme.clickme.svg.domain.document.SvgDocumentFactory;
+import clickme.clickme.svg.domain.document.SvgDocumentManipulator;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
+import org.w3c.dom.Document;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class GcsSvgGenerationStrategy implements SvgGenerationStrategy {
+
+    private final SvgDocumentFactory svgDocumentFactory;
+    private final SvgDocumentManipulator svgDocumentManipulator;
+    private final Storage storage;
+    private final String bucketName;
+    private final MemberRepository memberRepository;
+
+    public GcsSvgGenerationStrategy(SvgDocumentFactory svgDocumentFactory,
+                                    SvgDocumentManipulator svgDocumentManipulator,
+                                    Storage storage,
+                                    String bucketName,
+                                    MemberRepository memberRepository) {
+        this.svgDocumentFactory = svgDocumentFactory;
+        this.svgDocumentManipulator = svgDocumentManipulator;
+        this.storage = storage;
+        this.bucketName = bucketName;
+        this.memberRepository = memberRepository;
+    }
+
+    @Override
+    public Document generateSvg(Count count, String name, String svgUrl) throws IOException {
+        Member member = memberRepository.findByName(name)
+                .orElseThrow(() -> new IOException("Member not found"));
+        String memberSvgUrl = member.getSvgUrl();
+        Document doc = loadSvgFromGcs(memberSvgUrl);
+        doc = svgDocumentManipulator.drawText(doc, count);
+        return doc;
+    }
+
+    private Document loadSvgFromGcs(String url) throws IOException {
+        String fileName = url.substring(url.lastIndexOf("/") + 1);
+        Blob blob = storage.get(bucketName, "svgs/" + fileName);
+        if (blob == null) {
+            throw new IOException("SVG file not found: " + fileName);
+        }
+        String svgContent = new String(blob.getContent(), StandardCharsets.UTF_8);
+        return svgDocumentFactory.createSvgDocumentFromString(svgContent);
+    }
+}

--- a/click-service/src/main/java/clickme/clickme/svg/domain/document/strategy/GcsSvgGenerationStrategy.java
+++ b/click-service/src/main/java/clickme/clickme/svg/domain/document/strategy/GcsSvgGenerationStrategy.java
@@ -33,9 +33,8 @@ public class GcsSvgGenerationStrategy implements SvgGenerationStrategy {
     }
 
     @Override
-    public Document generateSvg(Count count, String name, String svgUrl) throws IOException {
-        Member member = memberRepository.findByName(name)
-                .orElseThrow(() -> new IOException("Member not found"));
+    public Document generateSvg(Count count, String name) throws IOException {
+        Member member = memberRepository.getMemberByName(name);
         String memberSvgUrl = member.getSvgUrl();
         Document doc = loadSvgFromGcs(memberSvgUrl);
         doc = svgDocumentManipulator.drawText(doc, count);

--- a/click-service/src/main/java/clickme/clickme/svg/domain/document/strategy/SvgGenerationStrategy.java
+++ b/click-service/src/main/java/clickme/clickme/svg/domain/document/strategy/SvgGenerationStrategy.java
@@ -1,0 +1,11 @@
+package clickme.clickme.svg.domain.document.strategy;
+
+import clickme.clickme.svg.domain.count.Count;
+import org.w3c.dom.Document;
+
+import java.io.IOException;
+
+public interface SvgGenerationStrategy {
+
+    Document generateSvg(Count count, String name, String svgUrl) throws IOException;
+}

--- a/click-service/src/main/java/clickme/clickme/svg/domain/document/strategy/SvgGenerationStrategy.java
+++ b/click-service/src/main/java/clickme/clickme/svg/domain/document/strategy/SvgGenerationStrategy.java
@@ -7,5 +7,5 @@ import java.io.IOException;
 
 public interface SvgGenerationStrategy {
 
-    Document generateSvg(Count count, String name, String svgUrl) throws IOException;
+    Document generateSvg(Count count, String name) throws IOException;
 }

--- a/click-service/src/main/java/clickme/clickme/svg/ui/SvgImageV1Controller.java
+++ b/click-service/src/main/java/clickme/clickme/svg/ui/SvgImageV1Controller.java
@@ -32,10 +32,10 @@ public class SvgImageV1Controller {
     }
 
     @GetMapping("/increment")
-    public ResponseEntity<String> getClickableSvgImageByName(@RequestParam final String name, @RequestParam final String svgUrl) {
+    public ResponseEntity<String> getClickableSvgImageByName(@RequestParam final String name) {
         return ResponseEntity.ok()
                 .contentType(SVG)
                 .cacheControl(DEFAULT_CACHE_CONTROL)
-                .body(svgImageService.generateClickableSvgImage(name, svgUrl));
+                .body(svgImageService.generateClickableSvgImage(name));
     }
 }

--- a/click-service/src/main/java/clickme/clickme/svg/ui/SvgImageV1Controller.java
+++ b/click-service/src/main/java/clickme/clickme/svg/ui/SvgImageV1Controller.java
@@ -23,18 +23,19 @@ public class SvgImageV1Controller {
     private final SvgImageService svgImageService;
 
     @GetMapping
-    public ResponseEntity<String> getNonClickableSvgImageByName(@RequestParam final String name) {
+    public ResponseEntity<String> getNonClickableSvgImageByName(@RequestParam final String name, @RequestParam final String svgUrl) {
+        System.out.println(svgUrl);
         return ResponseEntity.ok()
                 .contentType(SVG)
                 .cacheControl(DEFAULT_CACHE_CONTROL)
-                .body(svgImageService.generateNonClickableSvgImage(name));
+                .body(svgImageService.generateNonClickableSvgImage(name, svgUrl));
     }
 
     @GetMapping("/increment")
-    public ResponseEntity<String> getClickableSvgImageByName(@RequestParam final String name) {
+    public ResponseEntity<String> getClickableSvgImageByName(@RequestParam final String name, @RequestParam final String svgUrl) {
         return ResponseEntity.ok()
                 .contentType(SVG)
                 .cacheControl(DEFAULT_CACHE_CONTROL)
-                .body(svgImageService.generateClickableSvgImage(name));
+                .body(svgImageService.generateClickableSvgImage(name, svgUrl));
     }
 }

--- a/click-service/src/main/java/clickme/clickme/svg/util/CoordinatesCalculator.java
+++ b/click-service/src/main/java/clickme/clickme/svg/util/CoordinatesCalculator.java
@@ -1,0 +1,17 @@
+package clickme.clickme.svg.util;
+
+import clickme.clickme.svg.domain.document.Coordinates;
+
+public class CoordinatesCalculator {
+
+    private CoordinatesCalculator() {
+    }
+
+    public static Coordinates calculateCoordinates(int width, int height) {
+        int circleX = (int) (width * 0.80);
+        int circleY = (int) (height * 0.20);
+        int textX = circleX;
+        int textY = (int) (height * 0.25);
+        return new Coordinates(circleX, circleY, textX, textY);
+    }
+}

--- a/click-service/src/main/java/clickme/clickme/upload/application/GcsService.java
+++ b/click-service/src/main/java/clickme/clickme/upload/application/GcsService.java
@@ -5,6 +5,7 @@ import com.google.cloud.storage.Storage;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 @Service
@@ -27,8 +28,7 @@ public class GcsService {
     public String uploadSvg(String svgContent) {
         String fileName = PREFIX_PATH + UUID.randomUUID() + FORMAT;
         Bucket bucket = storage.get(bucketName);
-        bucket.create(fileName, svgContent.getBytes(), SVG_TYPE);
-
+        bucket.create(fileName, svgContent.getBytes(StandardCharsets.UTF_8), SVG_TYPE);
         return String.format(DEFAULT_STORAGE_URL, bucketName, fileName);
     }
 }

--- a/click-service/src/main/java/clickme/clickme/upload/application/GcsService.java
+++ b/click-service/src/main/java/clickme/clickme/upload/application/GcsService.java
@@ -1,0 +1,29 @@
+package clickme.clickme.upload.application;
+
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class GcsService {
+
+    private final Storage storage;
+
+    @Value("${gcp.storage.bucket-name}")
+    private String bucketName;
+
+    public GcsService(final Storage storage) {
+        this.storage = storage;
+    }
+
+    public String uploadSvg(String svgContent) {
+        String fileName = "svgs/" + UUID.randomUUID() + ".svg";
+        Bucket bucket = storage.get(bucketName);
+        bucket.create(fileName, svgContent.getBytes(), "image/svg+xml");
+
+        return String.format("https://storage.googleapis.com/%s/%s", bucketName, fileName);
+    }
+}

--- a/click-service/src/main/java/clickme/clickme/upload/application/GcsService.java
+++ b/click-service/src/main/java/clickme/clickme/upload/application/GcsService.java
@@ -10,6 +10,11 @@ import java.util.UUID;
 @Service
 public class GcsService {
 
+    private static final String PREFIX_PATH = "svgs/";
+    private static final String FORMAT = ".svg";
+    private static final String SVG_TYPE = "image/svg+xml";
+    private static final String DEFAULT_STORAGE_URL = "https://storage.googleapis.com/%s/%s";
+
     private final Storage storage;
 
     @Value("${gcp.storage.bucket-name}")
@@ -20,10 +25,10 @@ public class GcsService {
     }
 
     public String uploadSvg(String svgContent) {
-        String fileName = "svgs/" + UUID.randomUUID() + ".svg";
+        String fileName = PREFIX_PATH + UUID.randomUUID() + FORMAT;
         Bucket bucket = storage.get(bucketName);
-        bucket.create(fileName, svgContent.getBytes(), "image/svg+xml");
+        bucket.create(fileName, svgContent.getBytes(), SVG_TYPE);
 
-        return String.format("https://storage.googleapis.com/%s/%s", bucketName, fileName);
+        return String.format(DEFAULT_STORAGE_URL, bucketName, fileName);
     }
 }

--- a/click-service/src/main/java/clickme/clickme/upload/application/GifToSvgService.java
+++ b/click-service/src/main/java/clickme/clickme/upload/application/GifToSvgService.java
@@ -1,0 +1,122 @@
+package clickme.clickme.upload.application;
+
+import clickme.clickme.upload.application.dto.SvgConvertResponse;
+import clickme.clickme.upload.application.exception.SvgConvertException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Base64;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GifToSvgService {
+
+    public static final String GIF = ".gif";
+
+    private final GcsService gcsService;
+
+    public SvgConvertResponse convertGifToSvg(MultipartFile gifFile) {
+        final UUID uuid = UUID.randomUUID();
+        Path uploadDir = null;
+        Path framesDir = null;
+        try {
+            uploadDir = Files.createTempDirectory("uploads_");
+            framesDir = Files.createTempDirectory("frames_").resolve(uuid.toString());
+            Files.createDirectories(framesDir);
+
+            Path gifPath = uploadDir.resolve(uuid + GIF);
+            try (InputStream inputStream = gifFile.getInputStream()) {
+                Files.copy(inputStream, gifPath, StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            String outputPattern = framesDir.resolve("frame-%03d.png").toString();
+            ProcessBuilder processBuilder = new ProcessBuilder(
+                    "ffmpeg", "-i", gifPath.toString(), outputPattern
+            );
+            processBuilder.redirectErrorStream(true);
+            Process process = processBuilder.start();
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                throw new IOException("ffmpeg 프로세스가 비정상 종료되었습니다. exitCode: " + exitCode);
+            }
+
+            File[] frames = framesDir.toFile().listFiles((dir, name) -> name.endsWith(".png"));
+            if (frames == null || frames.length == 0) {
+                throw new IOException("GIF 프레임을 추출할 수 없습니다.");
+            }
+
+            String svgContent = generateSvg(frames);
+
+            String svgUrl = gcsService.uploadSvg(svgContent);
+            log.info("SVG 파일이 저장되었습니다: {}", svgUrl);
+            return new SvgConvertResponse(svgUrl);
+        } catch (IOException | InterruptedException e) {
+            log.error("GIF 변환 중 오류 발생: {}", e.getMessage());
+            throw new SvgConvertException();
+        } finally {
+            if (framesDir != null) {
+                try {
+                    FileUtils.deleteDirectory(framesDir.toFile());
+                } catch (IOException e) {
+                    log.warn("framesDir 삭제 실패: {}", e.getMessage());
+                }
+            }
+            if (uploadDir != null) {
+                try {
+                    FileUtils.deleteDirectory(uploadDir.toFile());
+                } catch (IOException e) {
+                    log.warn("uploadDir 삭제 실패: {}", e.getMessage());
+                }
+            }
+        }
+    }
+
+    private String generateSvg(File[] frames) throws IOException {
+        double rate = 0.1;
+        StringBuilder svg = new StringBuilder();
+        svg.append("<svg width=\"300\" height=\"150\" viewBox=\"0 0 300 150\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<style>\n");
+        svg.append("@keyframes anim {");
+        svg.append("0% { opacity: 1; }\n");
+        svg.append("4.16% { opacity: 1; }\n");
+        svg.append("8.33% { opacity: 0; }\n");
+        svg.append("100% { opacity: 0; } }\n");
+
+        svg.append("image { opacity: 0; animation: anim ")
+                .append(rate * frames.length).append("s linear infinite; }\n");
+
+        StringBuilder svgImages = new StringBuilder();
+        for (int i = 0; i < frames.length; i++) {
+            String base64 = encodeImageToBase64(frames[i]);
+            svg.append("image#img").append(i)
+                    .append(" { animation-delay: ").append(String.format("%.2f", i * rate)).append("s; }\n");
+
+            svgImages.append("<image id=\"img").append(i)
+                    .append("\" xlink:href=\"data:image/png;base64,").append(base64)
+                    .append("\" width=\"100%\" height=\"100%\" />\n");
+        }
+
+        svg.append("</style>\n");
+        svg.append(svgImages);
+        svg.append("<circle id=\"my-circle\" r=\"28\" fill=\"rgba(255, 255, 255, 0.8)\" stroke=\"black\" stroke-width=\"2\"/>");
+        svg.append("<text id=\"my-text\" x=\"250\" y=\"38\" font-size=\"20\" font-weight=\"bold\" text-anchor=\"middle\" fill=\"black\"></text>");
+        svg.append("</svg>");
+
+        return svg.toString();
+    }
+
+    private String encodeImageToBase64(File imageFile) throws IOException {
+        byte[] fileContent = FileUtils.readFileToByteArray(imageFile);
+        return Base64.getEncoder().encodeToString(fileContent);
+    }
+}

--- a/click-service/src/main/java/clickme/clickme/upload/application/dto/SvgConvertResponse.java
+++ b/click-service/src/main/java/clickme/clickme/upload/application/dto/SvgConvertResponse.java
@@ -1,0 +1,4 @@
+package clickme.clickme.upload.application.dto;
+
+public record SvgConvertResponse(String svgUrl) {
+}

--- a/click-service/src/main/java/clickme/clickme/upload/application/exception/SvgConvertException.java
+++ b/click-service/src/main/java/clickme/clickme/upload/application/exception/SvgConvertException.java
@@ -1,0 +1,11 @@
+package clickme.clickme.upload.application.exception;
+
+import clickme.clickme.common.BusinessException;
+import clickme.clickme.common.ErrorCode;
+
+public class SvgConvertException extends BusinessException {
+
+    public SvgConvertException() {
+        super(ErrorCode.SVG_CONVERSION_FAILED);
+    }
+}

--- a/click-service/src/main/java/clickme/clickme/upload/ui/GifToSvgController.java
+++ b/click-service/src/main/java/clickme/clickme/upload/ui/GifToSvgController.java
@@ -1,0 +1,26 @@
+package clickme.clickme.upload.ui;
+
+import clickme.clickme.upload.application.GifToSvgService;
+import clickme.clickme.upload.application.dto.SvgConvertResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1")
+public class GifToSvgController {
+
+    private final GifToSvgService gifToSvgService;
+
+    public GifToSvgController(GifToSvgService gifToSvgService) {
+        this.gifToSvgService = gifToSvgService;
+    }
+
+    @PostMapping("/convert")
+    public ResponseEntity<SvgConvertResponse> convertGifToSvg(@RequestParam("gif") MultipartFile file) {
+        return ResponseEntity.ok(gifToSvgService.convertGifToSvg(file));
+    }
+}

--- a/click-service/src/main/resources/application-prod.yml
+++ b/click-service/src/main/resources/application-prod.yml
@@ -57,3 +57,9 @@ management:
       export:
         enabled: true
         step: 1m
+
+gcp:
+  storage:
+    bucket-name: ${BUKET_NAME}
+    credentials:
+      location: classpath:credentials.json

--- a/click-service/src/main/resources/application-prod.yml
+++ b/click-service/src/main/resources/application-prod.yml
@@ -61,5 +61,3 @@ management:
 gcp:
   storage:
     bucket-name: ${BUKET_NAME}
-    credentials:
-      location: classpath:credentials.json

--- a/click-service/src/main/resources/application.yml
+++ b/click-service/src/main/resources/application.yml
@@ -70,6 +70,4 @@ management:
 gcp:
   storage:
     bucket-name: test
-    credentials:
-      location: classpath:credentials.json
 

--- a/click-service/src/main/resources/application.yml
+++ b/click-service/src/main/resources/application.yml
@@ -69,7 +69,7 @@ management:
 
 gcp:
   storage:
-    bucket-name: ${BUKET_NAME}
+    bucket-name: test
     credentials:
       location: classpath:credentials.json
 

--- a/click-service/src/main/resources/application.yml
+++ b/click-service/src/main/resources/application.yml
@@ -1,4 +1,11 @@
 spring:
+  servlet:
+    multipart:
+      location: uploads/
+      enabled: true
+      max-file-size: 10MB
+      file-size-threshold: 2MB
+      max-request-size: 10MB
   jackson:
     time-zone: Asia/Seoul
   data:
@@ -59,3 +66,10 @@ management:
       export:
         enabled: true
         step: 1m
+
+gcp:
+  storage:
+    bucket-name: ${BUKET_NAME}
+    credentials:
+      location: classpath:credentials.json
+

--- a/click-service/src/main/resources/db/migration/V3__member_add_svgUrl.sql
+++ b/click-service/src/main/resources/db/migration/V3__member_add_svgUrl.sql
@@ -1,0 +1,1 @@
+ALTER TABLE member ADD COLUMN svgUrl varchar(255) DEFAULT NULL;

--- a/click-service/src/test/java/clickme/clickme/acceptance/SvgAcceptanceTest.java
+++ b/click-service/src/test/java/clickme/clickme/acceptance/SvgAcceptanceTest.java
@@ -20,12 +20,14 @@ class SvgAcceptanceTest extends AcceptanceTest {
     private SvgImageService svgImageService;
 
     @Test
-    void 비활성_svg_이미지를_가져온다() throws Exception {
+    void 비활성_svg_이미지를_가져온다() {
         String name = "seungpang";
         String svgContent = "<svg>Non-clickable content</svg>";
+        String dummySvgUrl = "dummySvgUrl";
 
-        when(svgImageService.generateNonClickableSvgImage(isA(String.class))).thenReturn(svgContent);
-        ExtractableResponse<Response> response = 비활성_svg_이미지_조회( name);
+        when(svgImageService.generateNonClickableSvgImage(isA(String.class), isA(String.class)))
+                .thenReturn(svgContent);
+        ExtractableResponse<Response> response = 비활성_svg_이미지_조회(name, dummySvgUrl);
 
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
@@ -35,7 +37,7 @@ class SvgAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 활성_svg_이미지를_가져온다() throws Exception {
+    void 활성_svg_이미지를_가져온다() {
         String name = "seungpang";
         String svgContent = "<svg>Clickable content</svg>";
 
@@ -57,19 +59,19 @@ class SvgAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 빈_이름_파라미터로_비활성_SVG_이미지를_가져온다() {
-        ExtractableResponse<Response> response = 비활성_svg_이미지_조회("");
-
+    void 빈_이름_파라미터로_비활성_svg_이미지를_가져온다() {
+        ExtractableResponse<Response> response = 비활성_svg_이미지_조회("", "dummySvgUrl");
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
     @Test
     void 서비스_예외_발생시_비활성_SVG_이미지를_가져오지_못하고_예외가_발생한다() {
         String name = "seungpang";
+        String dummySvgUrl = "dummySvgUrl";
 
-        when(svgImageService.generateNonClickableSvgImage(isA(String.class)))
+        when(svgImageService.generateNonClickableSvgImage(isA(String.class), isA(String.class)))
                 .thenThrow(new SvgException("Service exception", ErrorCode.INTERNAL_SERVER_ERROR));
-        ExtractableResponse<Response> response = 비활성_svg_이미지_조회(name);
+        ExtractableResponse<Response> response = 비활성_svg_이미지_조회(name, dummySvgUrl);
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
     }
@@ -89,9 +91,11 @@ class SvgAcceptanceTest extends AcceptanceTest {
     void 비활성_SVG_이미지의_캐시_컨트롤_헤더에_값이_정상적인지_확인한다() throws Exception {
         String name = "seungpang";
         String svgContent = "<svg>Non-clickable content</svg>";
+        String dummySvgUrl = "dummySvgUrl";
 
-        when(svgImageService.generateNonClickableSvgImage(isA(String.class))).thenReturn(svgContent);
-        ExtractableResponse<Response> response = 비활성_svg_이미지_조회(name);
+        when(svgImageService.generateNonClickableSvgImage(isA(String.class), isA(String.class)))
+                .thenReturn(svgContent);
+        ExtractableResponse<Response> response = 비활성_svg_이미지_조회(name, dummySvgUrl);
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(response.header("Cache-Control")).isEqualTo("max-age=1");
@@ -111,8 +115,8 @@ class SvgAcceptanceTest extends AcceptanceTest {
         );
     }
 
-    private static ExtractableResponse<Response> 비활성_svg_이미지_조회(final String name) {
-        return AcceptanceFixture.get("/api/v1/svg-image?name=" + name);
+    private static ExtractableResponse<Response> 비활성_svg_이미지_조회(final String name, final String svgUrl) {
+        return AcceptanceFixture.get("/api/v1/svg-image?name=" + name + "&svgUrl=" + svgUrl);
     }
 
     private static ExtractableResponse<Response> 활성_svg_이미지_조회(final String name) {

--- a/click-service/src/test/java/clickme/clickme/svg/application/SvgImageServiceTest.java
+++ b/click-service/src/test/java/clickme/clickme/svg/application/SvgImageServiceTest.java
@@ -2,10 +2,13 @@ package clickme.clickme.svg.application;
 
 import clickme.clickme.ranking.domain.DailyClickMemoryRepository;
 import clickme.clickme.ranking.domain.DailyClickRepository;
+import clickme.clickme.ranking.domain.MemberRepository;
 import clickme.clickme.ranking.domain.RankingMemoryRepository;
 import clickme.clickme.ranking.domain.RankingRepository;
 import clickme.clickme.svg.domain.document.SvgDocumentFactory;
 import clickme.clickme.svg.domain.document.SvgDocumentManipulator;
+import clickme.clickme.svg.domain.document.SvgTransformer;
+import com.google.cloud.storage.Storage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,11 +36,28 @@ class SvgImageServiceTest {
     @Autowired
     private SvgDocumentManipulator svgDocumentManipulator;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private Storage storage;
+
+    @Autowired
+    private SvgTransformer svgTransformer;
+
     @BeforeEach
     void setUp() {
         rankingRepository = new RankingMemoryRepository();
         dailyClickRepository = new DailyClickMemoryRepository();
-        svgImageService = new SvgImageService(rankingRepository, dailyClickRepository, svgDocumentFactory, svgDocumentManipulator);
+        svgImageService = new SvgImageService(
+                rankingRepository,
+                dailyClickRepository,
+                svgDocumentFactory,
+                svgDocumentManipulator,
+                memberRepository,
+                storage,
+                svgTransformer
+        );
         rankingRepository.add(SEUNGPANG);
     }
 
@@ -55,7 +75,7 @@ class SvgImageServiceTest {
     @Test
     @DisplayName("카운트가 오르지 않고 svg 이미지가 정상적으로 호출된다.")
     void generateNonClickableSvgImage() {
-        final String svg = svgImageService.generateNonClickableSvgImage(SEUNGPANG);
+        final String svg = svgImageService.generateNonClickableSvgImage(SEUNGPANG, "null");
 
         assertAll(
                 () -> assertThat(rankingRepository.findByName(SEUNGPANG)).isEqualTo(0L),

--- a/click-service/src/test/java/clickme/clickme/svg/domain/document/SvgDocumentManipulatorTest.java
+++ b/click-service/src/test/java/clickme/clickme/svg/domain/document/SvgDocumentManipulatorTest.java
@@ -34,11 +34,11 @@ class SvgDocumentManipulatorTest {
     @ParameterizedTest(name = "카운트 수가 {0}인 경우")
     @ValueSource(ints = {1, 10, 100, 1000, 10000, 10000, 100000})
     @DisplayName("카운트 수의 길이에 따라 텍스트의 설정값들이 정상적으로 설정된다.")
-    void drawText(final long num) throws IOException {
+    void drawDefaultText(final long num) throws IOException {
         Document doc = svgDocumentFactory.createEmojiDocument();
 
         final Count count = new Count(num);
-        final Document resultDoc = svgDocumentManipulator.drawText(doc, count);
+        final Document resultDoc = svgDocumentManipulator.drawDefaultText(doc, count);
 
         final Element textElement = resultDoc.getElementById("my-text");
         assertAll(

--- a/click-service/src/test/java/clickme/clickme/svg/ui/SvgImageV1ControllerTest.java
+++ b/click-service/src/test/java/clickme/clickme/svg/ui/SvgImageV1ControllerTest.java
@@ -30,11 +30,12 @@ class SvgImageV1ControllerTest {
     @Test
     void getNonClickableSvgImageByName() throws Exception {
         String name = "seungpang";
+        String svgUrl = "null";
         String expected = "seungpang click count";
-        when(svgImageService.generateNonClickableSvgImage(isA(String.class)))
+        when(svgImageService.generateNonClickableSvgImage(isA(String.class), isA(String.class)))
                 .thenReturn(expected);
 
-        final ResultActions response = mockMvc.perform(get("/api/v1/svg-image?name=" + name));
+        final ResultActions response = mockMvc.perform(get("/api/v1/svg-image?name=" + name + "&svgUrl=" + svgUrl));
 
         response.andExpect(status().isOk())
                 .andDo(MockMvcResultHandlers.print())


### PR DESCRIPTION
## 구현 상세
+ gif이미지를 프레임으로 분리
+ 분리한 이미지로 svg 이미지를 생성
+ 해당 svg이미지의 크기를 측정해 클릭카운트를 표기할 위치를 계산하고 작성
+ 기존 api와 함께 사용하기 위해 처음 등록할때만 gif이미지의 url을 받고 저장, member에 svgUrl이 있다면 gif이미지 없다면 기존 이미지로 전달